### PR TITLE
Refactor LayoutContainer with semantic size naming

### DIFF
--- a/playground/src/components/LayoutDemo.tsx
+++ b/playground/src/components/LayoutDemo.tsx
@@ -102,11 +102,9 @@ export function LayoutDemo() {
         <div className="space-y-2">
           <div className="demo-label">LayoutContainer maxWidth</div>
           <div className="text-sm text-navy-600 space-y-1">
-            <p><code className="bg-gray-100 px-1 rounded">sm</code> - max-w-sm (24rem / 384px)</p>
-            <p><code className="bg-gray-100 px-1 rounded">md</code> - max-w-md (28rem / 448px)</p>
-            <p><code className="bg-gray-100 px-1 rounded">lg</code> - max-w-lg (32rem / 512px) - default</p>
-            <p><code className="bg-gray-100 px-1 rounded">xl</code> - max-w-xl (36rem / 576px)</p>
-            <p><code className="bg-gray-100 px-1 rounded">2xl</code> - max-w-2xl (42rem / 672px)</p>
+            <p><code className="bg-gray-100 px-1 rounded">narrow</code> - max-w-lg (32rem / 512px) - default</p>
+            <p><code className="bg-gray-100 px-1 rounded">medium</code> - max-w-3xl (48rem / 768px)</p>
+            <p><code className="bg-gray-100 px-1 rounded">wide</code> - max-w-5xl (64rem / 1024px)</p>
           </div>
         </div>
       </section>
@@ -141,8 +139,8 @@ import { Settings } from 'lucide-react'
   ]}
   onLogout={() => signOut()}
 
-  // Content width
-  maxWidth="lg"
+  // Content width: "narrow" (default), "medium", or "wide"
+  maxWidth="narrow"
 >
   <LayoutContainer>
     <p>Page content goes here</p>

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -5,14 +5,15 @@ import { GPLogo } from "../Logo";
 import { Sidebar } from "../Sidebar/Sidebar";
 import { SidebarProvider, useSidebar } from "../Sidebar/SidebarContext";
 import type { SidebarItem, SidebarGroup } from "../Sidebar/types";
+import { cn } from "../../utils/cn";
 
-const MAX_WIDTH_CLASSES = {
-  sm: "max-w-sm",
-  md: "max-w-md",
-  lg: "max-w-lg",
-  xl: "max-w-xl",
-  "2xl": "max-w-2xl",
-} as const;
+export type MaxWidthSize = "narrow" | "medium" | "wide";
+
+const MAX_WIDTH_CLASSES: Record<MaxWidthSize, string> = {
+  narrow: "max-w-lg",
+  medium: "max-w-3xl",
+  wide: "max-w-5xl",
+};
 
 export interface LayoutUser {
   name?: string;
@@ -48,7 +49,7 @@ export interface LayoutProps {
   title?: string;
   showBackButton?: boolean;
   headerRight?: ReactNode;
-  maxWidth?: "sm" | "md" | "lg" | "xl" | "2xl";
+  maxWidth?: MaxWidthSize;
   banner?: LayoutBanner;
   searchBar?: ReactNode;
   isHomePage?: boolean;
@@ -201,7 +202,7 @@ interface LayoutContentProps {
   user?: LayoutUser;
   menuItems: LayoutMenuItem[];
   onLogout?: () => void;
-  maxWidth: "sm" | "md" | "lg" | "xl" | "2xl";
+  maxWidth: MaxWidthSize;
   banner?: LayoutBanner;
   searchBar?: ReactNode;
   sidebar?: LayoutSidebar;
@@ -269,7 +270,7 @@ function LayoutContent({
             {/* Search bar */}
             {searchBar && (
               <div className="sticky top-0 z-10 bg-white border-b border-gray-200 px-4 py-3">
-                <div className={`${MAX_WIDTH_CLASSES[maxWidth]} mx-auto`}>
+                <div className={cn(MAX_WIDTH_CLASSES[maxWidth], "mx-auto")}>
                   {searchBar}
                 </div>
               </div>
@@ -318,7 +319,7 @@ function LayoutContent({
       {/* Search bar */}
       {searchBar && (
         <div className="sticky top-0 z-10 bg-white border-b border-gray-200 px-4 py-3">
-          <div className={`${MAX_WIDTH_CLASSES[maxWidth]} mx-auto`}>
+          <div className={cn(MAX_WIDTH_CLASSES[maxWidth], "mx-auto")}>
             {searchBar}
           </div>
         </div>
@@ -335,7 +336,7 @@ export function Layout({
   title,
   showBackButton = false,
   headerRight,
-  maxWidth = "lg",
+  maxWidth = "narrow",
   banner,
   searchBar,
   isHomePage = false,
@@ -392,15 +393,15 @@ export function Layout({
 
 export interface LayoutContainerProps {
   children: ReactNode;
-  maxWidth?: "sm" | "md" | "lg" | "xl" | "2xl";
+  maxWidth?: MaxWidthSize;
 }
 
 export function LayoutContainer({
   children,
-  maxWidth = "lg",
+  maxWidth = "narrow",
 }: LayoutContainerProps) {
   return (
-    <div className={`${MAX_WIDTH_CLASSES[maxWidth]} mx-auto px-4 py-4`}>
+    <div className={cn(MAX_WIDTH_CLASSES[maxWidth], "mx-auto px-4 py-4")}>
       {children}
     </div>
   );

--- a/src/components/Layout/index.ts
+++ b/src/components/Layout/index.ts
@@ -1,2 +1,2 @@
 export { Layout, LayoutContainer } from './Layout'
-export type { LayoutProps, LayoutUser, LayoutBanner, LayoutMenuItem, LayoutContainerProps } from './Layout'
+export type { LayoutProps, LayoutUser, LayoutBanner, LayoutMenuItem, LayoutContainerProps, MaxWidthSize } from './Layout'


### PR DESCRIPTION
Replace direct Tailwind class mappings (sm, md, lg, xl, 2xl) with three semantic size options: "narrow" (max-w-lg), "medium" (max-w-3xl), and "wide" (max-w-5xl). This provides a larger maximum width option while reducing API surface. Also switches from string template literals to cn() helper for class construction.