### PR TITLE
Add system theme option to ToggleDarkMode

### DIFF
--- a/src/components/ToggleDarkMode/index.ts
+++ b/src/components/ToggleDarkMode/index.ts
@@ -1,2 +1,2 @@
 export { ToggleDarkMode } from './ToggleDarkMode'
-export type { ToggleDarkModeProps } from './ToggleDarkMode'
+export type { ToggleDarkModeProps, ThemePreference } from './ToggleDarkMode'


### PR DESCRIPTION
## Summary
- ToggleDarkMode now cycles through three states: light → dark → system
- "System" mode honors the OS `prefers-color-scheme` setting and reacts to changes in real time
- Legacy boolean `localStorage` values (`"true"`/`"false"`) are migrated automatically
- New `ThemePreference` type and `systemLabel` prop exported for consumers

## Test plan
- [ ] Click the toggle in the playground header and verify it cycles: Light (Sun) → Dark (Moon) → System (Monitor)
- [ ] In System mode, change OS dark mode setting and verify the UI updates immediately
- [ ] Refresh the page and verify the selected preference persists
- [ ] Clear localStorage and verify it defaults to System mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)