### PR TITLE
Apply Dixie refresh style deltas

### DIFF
--- a/playground/src/components/ProportionChartDemo.tsx
+++ b/playground/src/components/ProportionChartDemo.tsx
@@ -177,6 +177,25 @@ export function ProportionChartDemo() {
               height="h-3"
             />
           </div>
+
+          <div>
+            <h3 className="text-sm font-medium text-navy-700 dark:text-navy-300 mb-2">
+              Fixed legend columns (no widow)
+            </h3>
+            <ProportionChart
+              data={statusData}
+              colors={statusColors}
+              formatValue={formatCount}
+              showLegend={true}
+              legendColumns={5}
+              height="h-3"
+            />
+            <p className="text-sm text-navy-500 dark:text-navy-400 mt-2">
+              <code className="text-xs bg-gray-100 dark:bg-navy-800 px-1 py-0.5 rounded">legendColumns</code> pins
+              the legend to a single row of N columns so a trailing item never wraps to a lonely second row.
+              Defaults to the number of visible segments.
+            </p>
+          </div>
         </div>
       </section>
 
@@ -266,6 +285,7 @@ const colors: Record<string, ColorConfig> = {
   formatValue={(n) => \`\${n} tasks\`}
   height="h-4"
   showLegend={true}
+  legendColumns={5} // pin to one row of 5 — no widow, never wraps
   ariaLabel="Task distribution by status"
 />
 

--- a/playground/src/components/SidebarDemo.tsx
+++ b/playground/src/components/SidebarDemo.tsx
@@ -29,6 +29,7 @@ export function SidebarDemo() {
         <p className="text-sm text-navy-600 dark:text-navy-400 mb-4">
           The Sidebar can be used outside of Layout by wrapping it in a SidebarProvider.
           Use SidebarLink and SidebarSection as children for a composable API.
+          The sidebar is chrome, so it renders navy in both light and dark mode; the active row carries the orange brand accent.
         </p>
 
         <div className="border border-gray-200 dark:border-navy-700 rounded-lg overflow-hidden">

--- a/src/components/Content/ContentPane.tsx
+++ b/src/components/Content/ContentPane.tsx
@@ -50,7 +50,7 @@ export function ContentPane({
   return (
     <div
       className={cn(
-        "flex-1 overflow-y-auto bg-gray-50 dark:bg-navy-950",
+        "flex-1 overflow-y-auto bg-cream dark:bg-navy-950",
         padding && "p-4 lg:p-6",
         className
       )}

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -227,7 +227,7 @@ function LayoutContent({
 
   if (hasSidebar) {
     return (
-      <div className="min-h-screen bg-gray-50 dark:bg-navy-950 flex flex-col">
+      <div className="min-h-screen bg-cream dark:bg-navy-950 flex flex-col">
         {/* Banner */}
         {banner && (
           <div className="bg-orange-500 text-white text-center py-1.5 text-xs font-medium flex items-center justify-center gap-2">
@@ -285,7 +285,7 @@ function LayoutContent({
 
   // Original layout without sidebar
   return (
-    <div className="min-h-screen bg-gray-50 dark:bg-navy-950">
+    <div className="min-h-screen bg-cream dark:bg-navy-950">
       {/* Banner */}
       {banner && (
         <div className="bg-orange-500 text-white text-center py-1.5 text-xs font-medium flex items-center justify-center gap-2">

--- a/src/components/ProportionChart/ProportionChart.tsx
+++ b/src/components/ProportionChart/ProportionChart.tsx
@@ -70,6 +70,15 @@ export interface ProportionChartProps extends HTMLAttributes<HTMLDivElement> {
   showLegend?: boolean
 
   /**
+   * Number of columns for the optional legend. Legend items lay out in a
+   * single row of this many columns and never wrap, so a trailing item can't
+   * become a lone "widow" on a second row. Set this to the maximum number of
+   * segments you expect for a stable layout across renders.
+   * @default the number of visible (non-zero) segments
+   */
+  legendColumns?: number
+
+  /**
    * Accessible label for screen readers
    */
   ariaLabel?: string
@@ -114,6 +123,7 @@ export function ProportionChart({
   formatValue,
   height = 'h-2',
   showLegend = false,
+  legendColumns,
   ariaLabel,
   className,
   ...props
@@ -221,19 +231,23 @@ export function ProportionChart({
         </Tooltip>
       </Tooltip.Provider>
 
-      {/* Legend (optional) */}
+      {/* Legend (optional) — single non-wrapping row so a trailing item never
+          becomes a lone "widow". Columns default to the visible segment count. */}
       {showLegend && (
         <div
-          className="mt-3 grid grid-cols-2 sm:grid-cols-5 gap-3"
+          className="mt-3 grid gap-3"
+          style={{
+            gridTemplateColumns: `repeat(${legendColumns ?? segments.length}, minmax(0, 1fr))`,
+          }}
           role="list"
           aria-label="Chart legend"
         >
           {segments.map((seg) => (
-            <div key={seg.key} className="flex items-center gap-2" role="listitem">
-              <span className={cn('w-3 h-3 rounded', seg.bg)} aria-hidden="true" />
-              <div>
-                <div className="text-xs text-gray-500 dark:text-gray-400">{seg.label}</div>
-                <div className="text-sm font-medium text-gray-900 dark:text-white">
+            <div key={seg.key} className="flex items-center gap-2 min-w-0" role="listitem">
+              <span className={cn('w-3 h-3 rounded flex-shrink-0', seg.bg)} aria-hidden="true" />
+              <div className="min-w-0">
+                <div className="text-xs text-gray-500 dark:text-gray-400 truncate">{seg.label}</div>
+                <div className="text-sm font-medium text-gray-900 dark:text-white truncate">
                   {formatValue(seg.value)}
                 </div>
               </div>

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -55,7 +55,7 @@ export function Sidebar({ items, children, header, footer, variant = "responsive
       {/* Sidebar panel */}
       <aside
         className={cn(
-          "flex flex-col bg-white dark:bg-navy-850 border-r border-gray-200 dark:border-navy-800 overflow-hidden",
+          "flex flex-col bg-navy-850 border-r border-navy-800 overflow-hidden",
           // Inline variant - uses container height, always visible
           variant === "inline" && "h-full",
           // Responsive variant - desktop sticky with viewport height
@@ -73,7 +73,7 @@ export function Sidebar({ items, children, header, footer, variant = "responsive
         {isMobile ? (
           <button
             onClick={closeSidebar}
-            className="absolute top-3 right-3 p-1 text-navy-400 dark:text-navy-400 hover:text-navy-600 dark:hover:text-navy-200 transition-colors"
+            className="absolute top-3 right-3 p-1 text-navy-400 hover:text-navy-200 transition-colors"
             aria-label="Close navigation"
           >
             <X className="w-5 h-5" aria-hidden="true" />
@@ -82,7 +82,7 @@ export function Sidebar({ items, children, header, footer, variant = "responsive
 
         {/* Header slot */}
         {header && (
-          <div className="border-b border-gray-200 dark:border-navy-800">
+          <div className="border-b border-navy-800">
             {header}
           </div>
         )}
@@ -107,7 +107,7 @@ export function Sidebar({ items, children, header, footer, variant = "responsive
 
         {/* Footer slot */}
         {footer && (
-          <div className="border-t border-gray-200 dark:border-navy-800">
+          <div className="border-t border-navy-800">
             {footer}
           </div>
         )}
@@ -116,7 +116,7 @@ export function Sidebar({ items, children, header, footer, variant = "responsive
         {!isMobile && (
           <button
             onClick={toggle}
-            className="flex items-center justify-center h-10 border-t border-gray-200 dark:border-navy-800 text-navy-400 dark:text-navy-400 hover:text-navy-600 dark:hover:text-navy-200 hover:bg-gray-50 dark:hover:bg-navy-800 transition-colors"
+            className="flex items-center justify-center h-10 border-t border-navy-800 text-navy-400 hover:text-navy-200 hover:bg-navy-800 transition-colors"
             aria-label={isCollapsed ? "Expand sidebar" : "Collapse sidebar"}
           >
             {isCollapsed ? (

--- a/src/components/Sidebar/SidebarGroup.tsx
+++ b/src/components/Sidebar/SidebarGroup.tsx
@@ -19,7 +19,7 @@ export function SidebarGroupComponent({
       {group.label && (
         <div
           className={cn(
-            "px-3 text-xs font-semibold text-navy-400 dark:text-navy-400 uppercase tracking-wider whitespace-nowrap transition-[opacity,margin]",
+            "px-3 text-xs font-semibold text-navy-400 uppercase tracking-wider whitespace-nowrap transition-[opacity,margin]",
             COLLAPSE_DURATION,
             collapsed ? "opacity-0 mb-0" : "opacity-100 mb-2"
           )}

--- a/src/components/Sidebar/SidebarItem.tsx
+++ b/src/components/Sidebar/SidebarItem.tsx
@@ -22,9 +22,9 @@ export function SidebarItemComponent({
 
   // Keep consistent padding so icon stays in same X position
   const baseClasses = cn(
-    "flex items-center gap-3 px-2 py-2 rounded-md text-sm font-medium transition-colors w-full",
-    "text-navy-600 dark:text-navy-300 hover:text-navy-900 dark:hover:text-white hover:bg-gray-100 dark:hover:bg-navy-700",
-    isActive && "bg-gray-100 dark:bg-navy-700 text-navy-900 dark:text-white"
+    "flex items-center gap-3 px-2 py-2 rounded-lg text-sm font-medium transition-colors w-full",
+    "text-navy-300 hover:text-white hover:bg-navy-700",
+    isActive && "bg-orange-500/[0.14] text-orange-300 hover:text-orange-300"
   );
 
   const content = (

--- a/src/components/Sidebar/SidebarLink.tsx
+++ b/src/components/Sidebar/SidebarLink.tsx
@@ -33,10 +33,10 @@ export function SidebarLink({
   };
 
   const baseClasses = cn(
-    "flex items-center gap-3 px-2 py-2 rounded-md text-sm font-medium transition-colors w-full",
-    "text-navy-600 dark:text-navy-300 hover:text-navy-900 dark:hover:text-white hover:bg-gray-100 dark:hover:bg-navy-700",
+    "flex items-center gap-3 px-2 py-2 rounded-lg text-sm font-medium transition-colors w-full",
+    "text-navy-300 hover:text-white hover:bg-navy-700",
     "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-orange-500",
-    isActive && "bg-gray-100 dark:bg-navy-700 text-navy-900 dark:text-white",
+    isActive && "bg-orange-500/[0.14] text-orange-300 hover:text-orange-300",
     className
   );
 

--- a/src/components/Sidebar/SidebarSearch.tsx
+++ b/src/components/Sidebar/SidebarSearch.tsx
@@ -38,7 +38,7 @@ export function SidebarSearch({
       <div className={cn("p-2", className)}>
         <button
           onClick={handleCollapsedClick}
-          className="w-full h-9 flex items-center justify-center rounded-md border border-gray-200 dark:border-navy-700 text-navy-400 dark:text-navy-400 hover:text-navy-600 dark:hover:text-navy-200 hover:border-gray-300 dark:hover:border-navy-600 hover:bg-gray-50 dark:hover:bg-navy-800 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-orange-500"
+          className="w-full h-9 flex items-center justify-center rounded-md border border-navy-700 text-navy-400 hover:text-navy-200 hover:border-navy-600 hover:bg-navy-800 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-orange-500"
           title={placeholder}
           aria-label={placeholder}
         >
@@ -52,7 +52,7 @@ export function SidebarSearch({
   return (
     <div className={cn("p-3", className)} role="search">
       <div className="relative">
-        <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 w-4 h-4 text-navy-400 dark:text-navy-400 pointer-events-none" />
+        <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 w-4 h-4 text-navy-400 pointer-events-none" />
         <input
           ref={inputRef}
           type="text"
@@ -61,7 +61,7 @@ export function SidebarSearch({
           onChange={(e) => setValue(e.target.value)}
           onKeyDown={handleKeyDown}
           aria-label={placeholder}
-          className="w-full pl-8 pr-3 py-1.5 text-sm border border-gray-200 dark:border-navy-700 rounded-md bg-white dark:bg-navy-800 placeholder:text-navy-400 dark:placeholder:text-navy-400 text-navy-900 dark:text-navy-100 focus:outline-none focus:ring-2 focus:ring-orange-500 focus:border-transparent"
+          className="w-full pl-8 pr-3 py-1.5 text-sm border border-navy-700 rounded-md bg-navy-800 placeholder:text-navy-400 text-navy-100 focus:outline-none focus:ring-2 focus:ring-orange-500 focus:border-transparent"
         />
       </div>
     </div>

--- a/src/components/Sidebar/SidebarSection.tsx
+++ b/src/components/Sidebar/SidebarSection.tsx
@@ -21,7 +21,7 @@ export function SidebarSection({
       {label && (
         <div
           className={cn(
-            "px-3 text-xs font-semibold text-navy-400 dark:text-navy-400 uppercase tracking-wider whitespace-nowrap transition-[opacity,margin]",
+            "px-3 text-xs font-semibold text-navy-400 uppercase tracking-wider whitespace-nowrap transition-[opacity,margin]",
             COLLAPSE_DURATION,
             isCollapsed ? "opacity-0 mb-0" : "opacity-100 mb-2"
           )}

--- a/src/components/Sidebar/SidebarUser.tsx
+++ b/src/components/Sidebar/SidebarUser.tsx
@@ -39,13 +39,13 @@ export function SidebarUser({
       className="w-full h-full rounded-full object-cover"
     />
   ) : (
-    <span className="text-navy-600 dark:text-navy-300 font-medium">{initials}</span>
+    <span className="text-navy-300 font-medium">{initials}</span>
   );
 
   // Same pattern as SidebarItemComponent - consistent padding, text fades out
   const content = (
     <div className="flex items-center gap-3 pl-2.5 pr-2 py-3">
-      <div className="w-8 h-8 rounded-full bg-navy-100 dark:bg-navy-700 flex items-center justify-center text-sm flex-shrink-0 overflow-hidden">
+      <div className="w-8 h-8 rounded-full bg-navy-700 flex items-center justify-center text-sm flex-shrink-0 overflow-hidden">
         {avatar}
       </div>
       <div
@@ -54,11 +54,11 @@ export function SidebarUser({
           isCollapsed ? "opacity-0" : "opacity-100"
         )}
       >
-        <div className="text-sm font-medium text-navy-900 dark:text-navy-100 truncate whitespace-nowrap">
+        <div className="text-sm font-medium text-navy-100 truncate whitespace-nowrap">
           {name}
         </div>
         {email && (
-          <div className="text-xs text-navy-500 dark:text-navy-300 truncate whitespace-nowrap">
+          <div className="text-xs text-navy-300 truncate whitespace-nowrap">
             {email}
           </div>
         )}
@@ -68,7 +68,7 @@ export function SidebarUser({
 
   const wrapperClasses = cn(
     "w-full transition-colors",
-    onClick && "cursor-pointer hover:bg-gray-100 dark:hover:bg-navy-800",
+    onClick && "cursor-pointer hover:bg-navy-800",
     className
   );
 

--- a/src/components/TabBar/TabBar.tsx
+++ b/src/components/TabBar/TabBar.tsx
@@ -58,7 +58,7 @@ export function TabBar({ items, activeId, onChange, variant = 'underline', class
     return (
       <div
         role="tablist"
-        className={cn('inline-flex items-center gap-1 p-1 rounded-full bg-navy-900/5 dark:bg-navy-800/60', className)}
+        className={cn('inline-flex items-center gap-1 p-1 rounded-full border border-gray-200 bg-navy-900/5 dark:border-navy-700 dark:bg-navy-800/60', className)}
       >
         {items.map((item) => {
           const isActive = activeId === item.id
@@ -70,8 +70,7 @@ export function TabBar({ items, activeId, onChange, variant = 'underline', class
               aria-selected={isActive}
               onClick={() => onChange(item.id)}
               className={cn(
-                'px-3 py-1 text-xs font-semibold uppercase whitespace-nowrap rounded-full transition-colors',
-                'tracking-wider',
+                'px-5 py-1.5 text-sm font-semibold whitespace-nowrap rounded-full transition-colors',
                 'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-orange-500',
                 isActive
                   ? 'bg-orange-500 text-white shadow-sm'

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -90,7 +90,7 @@
 /* Component classes */
 @layer components {
   .gp-card {
-    @apply bg-white rounded-card shadow-sm p-4;
+    @apply bg-white rounded-card border border-gray-200 shadow-sm p-4;
     @apply dark:bg-navy-900 dark:border dark:border-navy-700 dark:shadow-none;
   }
 


### PR DESCRIPTION
Style + layout changes to match the Dixie session + dashboard mocks, plus a couple of follow-up tunes.

## Changes

| # | Change | File(s) | Risk |
|---|--------|---------|------|
| 1 | Light-mode card border | `theme.css` `.gp-card` | low |
| 2 | Pill TabBar → segmented control | `TabBar.tsx` | low |
| 3 | Orange-tinted active nav item | `SidebarLink.tsx` / `SidebarItem.tsx` | low |
| 4 | Always-navy sidebar chrome | `Sidebar.tsx` + sub-components | brand decision |
| 5 | Cream page background in light mode | `Layout.tsx` / `ContentPane.tsx` | low |
| 6 | Non-wrapping ProportionChart legend | `ProportionChart.tsx` | low |

### 1 — Card light-mode border
`.gp-card` gets a hairline `border-gray-200` in light mode for cleaner separation on the cream page (dark unchanged).

### 2 — Pill TabBar → segmented control
The pill `TabBar` drops the uppercase/tracking treatment, sizes up (`px-5 py-1.5 text-sm`), and gets a container border so it reads as a modern segmented control. Active state unchanged. (This doubles as the "button group in pill mode" control — session sub-nav, dashboard time-range switch.)

### 3 — Orange-tinted active nav item
The active nav row now carries the orange brand accent. Applied to **both** `SidebarLink` (compound API) and `SidebarItem` (the `items`-prop API) so the two code paths stay visually identical, plus softer `rounded-lg` corners.

### 4 — Always-navy sidebar chrome (brand decision)
The sidebar is chrome, so it now renders navy in both light and dark mode. Reworked `SidebarLink`, `SidebarItem`, `SidebarUser`, `SidebarSearch`, `SidebarSection`, `SidebarGroup`, and the collapse toggle to their on-navy treatment (collapsing the redundant `light dark:` pairs into a single navy treatment) so text stays readable on navy in light mode.

### 5 — Cream page background in light mode
The main content area fell back to `bg-gray-50` in light mode; it now uses the `cream` brand token (`Layout.tsx` ×2 page wrappers + `ContentPane.tsx`). Dark (`navy-950`) unchanged. Dropdown-menu hover states keep `bg-gray-50` (chrome).

### 6 — Non-wrapping ProportionChart legend
Added a `legendColumns?: number` prop (defaults to the visible segment count). The legend now lays out in a single non-wrapping row of that many columns, so a trailing item can't become a lone "widow" on a second row. Labels/values `truncate`. Note: this drops the old responsive `grid-cols-2 sm:grid-cols-5` — a wide legend stays one row on narrow viewports rather than reflowing.

## Playground
- `SidebarDemo` note updated to reflect always-navy chrome.
- `ProportionChartDemo` gains a "Fixed legend columns (no widow)" example + usage note.

## Verification
- `npm run build` ✓
- `npm run typecheck` ✓
- `npm run lint` ✓
- `npm run test:run` ✓ (63 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
