### PR TITLE
Refresh Badge and StatCard for Dixie dashboard

### DIFF
--- a/playground/src/components/BadgeDemo.tsx
+++ b/playground/src/components/BadgeDemo.tsx
@@ -24,6 +24,33 @@ export function BadgeDemo() {
       </section>
 
       <section className="demo-section">
+        <h2 className="demo-section-title">With Count</h2>
+        <p className="demo-label">
+          A monospace count sits on the leading edge for flags, or the trailing
+          edge for category tags.
+        </p>
+        <div className="demo-row">
+          <Badge variant="warning" count={10}>
+            sessions flagged as anomalous
+          </Badge>
+          <Badge variant="error" count={16}>
+            stalled sessions
+          </Badge>
+        </div>
+        <div className="demo-row">
+          <Badge variant="neutral" count={525} countPosition="trailing">
+            other
+          </Badge>
+          <Badge variant="neutral" count={186} countPosition="trailing">
+            outcome
+          </Badge>
+          <Badge variant="info" count={42} countPosition="trailing">
+            planning
+          </Badge>
+        </div>
+      </section>
+
+      <section className="demo-section">
         <h2 className="demo-section-title">With Icons</h2>
         <div className="demo-row">
           <Badge variant="success" icon={<Check className="w-3 h-3" />}>
@@ -167,6 +194,10 @@ import { Check } from 'lucide-react'
 
 // With icon
 <Badge variant="success" icon={<Check />}>Synced</Badge>
+
+// With a count (leading for flags, trailing for tags)
+<Badge variant="warning" count={10}>flagged sessions</Badge>
+<Badge variant="neutral" count={525} countPosition="trailing">other</Badge>
 
 // Different sizes
 <Badge size="sm">Small</Badge>

--- a/playground/src/components/StatCardDemo.tsx
+++ b/playground/src/components/StatCardDemo.tsx
@@ -117,6 +117,38 @@ export function StatCardDemo() {
       </section>
 
       <section className="demo-section">
+        <h2 className="demo-section-title">Surface: muted vs plain</h2>
+        <p className="text-sm text-navy-600 dark:text-navy-400 mb-4">
+          Default tiles are <code>surface="muted"</code> (filled) — the right look on a
+          page background. Inside a Card/SectionCard the fill goes muddy grey-on-white,
+          so pass <code>surface="plain"</code> to make the tile transparent and inherit
+          the card behind it.
+        </p>
+        <div className="grid gap-4 sm:grid-cols-2">
+          <div>
+            <div className="demo-label">muted (default) inside a card — muddy</div>
+            <div className="bg-white dark:bg-navy-800 rounded-lg p-4 shadow-sm">
+              <div className="grid grid-cols-3 gap-3">
+                <StatCard label="Sent" value={142} variant="centered" />
+                <StatCard label="Received" value={98} variant="centered" />
+                <StatCard label="Threads" value={45} variant="centered" />
+              </div>
+            </div>
+          </div>
+          <div>
+            <div className="demo-label">plain inside a card — clean</div>
+            <div className="bg-white dark:bg-navy-800 rounded-lg p-4 shadow-sm">
+              <div className="grid grid-cols-3 gap-3">
+                <StatCard label="Sent" value={142} variant="centered" surface="plain" />
+                <StatCard label="Received" value={98} variant="centered" surface="plain" />
+                <StatCard label="Threads" value={45} variant="centered" surface="plain" />
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="demo-section">
         <h2 className="demo-section-title">Real-world Example</h2>
         <div className="bg-white dark:bg-navy-800 rounded-lg p-4 shadow-sm max-w-md">
           <h3 className="font-semibold text-navy-900 dark:text-navy-100 mb-3">Contact Summary</h3>
@@ -161,7 +193,10 @@ import { Mail } from 'lucide-react'
   value="150"
   variant="inline"
   color="accent"
-/>`}</pre>
+/>
+
+// Plain surface — transparent tile for nesting inside a Card
+<StatCard label="Sent" value={142} variant="centered" surface="plain" />`}</pre>
       </section>
     </div>
   )

--- a/src/components/Badge/Badge.test.tsx
+++ b/src/components/Badge/Badge.test.tsx
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { Check } from 'lucide-react'
+import { Badge } from './Badge'
+
+describe('Badge', () => {
+  describe('variants', () => {
+    it('applies the variant class for the chosen variant', () => {
+      render(<Badge variant="warning">Pending</Badge>)
+      expect(screen.getByText('Pending')).toHaveClass('gp-badge-warning')
+    })
+
+    it('defaults to the neutral variant', () => {
+      render(<Badge>Draft</Badge>)
+      expect(screen.getByText('Draft')).toHaveClass('gp-badge-neutral')
+    })
+  })
+
+  describe('count', () => {
+    it('renders the count when provided', () => {
+      render(<Badge count={10}>flagged</Badge>)
+      expect(screen.getByText('10')).toBeInTheDocument()
+    })
+
+    it('omits the count element when count is not provided', () => {
+      const { container } = render(<Badge>plain</Badge>)
+      expect(container.querySelector('.font-mono')).toBeNull()
+    })
+
+    it('renders a zero count (count={0} is not treated as absent)', () => {
+      render(<Badge count={0}>none</Badge>)
+      expect(screen.getByText('0')).toBeInTheDocument()
+    })
+
+    it('places the count before the label by default (leading)', () => {
+      const { container } = render(<Badge count={7}>items</Badge>)
+      expect(container.firstChild?.textContent).toBe('7items')
+    })
+
+    it('places the count after the label when countPosition="trailing"', () => {
+      const { container } = render(
+        <Badge count={525} countPosition="trailing">
+          other
+        </Badge>
+      )
+      expect(container.firstChild?.textContent).toBe('other525')
+    })
+  })
+
+  describe('icon', () => {
+    it('renders an icon in the leading slot', () => {
+      render(
+        <Badge icon={<Check data-testid="badge-icon" />}>Synced</Badge>
+      )
+      expect(screen.getByTestId('badge-icon')).toBeInTheDocument()
+    })
+  })
+})

--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -25,6 +25,19 @@ export interface BadgeProps {
   icon?: ReactNode
 
   /**
+   * Optional monospace count rendered inside the badge (e.g. a session or
+   * item total). Tabular figures keep it aligned across rows.
+   */
+  count?: number | string
+
+  /**
+   * Which edge the count sits on.
+   * - leading: before the label (default) — reads as "10 flagged"
+   * - trailing: after the label — reads as "other 525"
+   */
+  countPosition?: 'leading' | 'trailing'
+
+  /**
    * Badge content
    */
   children: ReactNode
@@ -50,6 +63,8 @@ export function Badge({
   variant = 'neutral',
   size = 'sm',
   icon,
+  count,
+  countPosition = 'leading',
   children,
   className = '',
 }: BadgeProps) {
@@ -61,9 +76,12 @@ export function Badge({
     neutral: 'gp-badge-neutral',
   }
 
+  // Geometry only — color and weight come from the gp-badge-* variant classes.
+  const baseClasses = 'inline-flex items-center rounded-full'
+
   const sizeClasses = {
-    sm: 'px-1.5 py-0.5 text-xs',
-    md: 'px-2 py-1 text-sm',
+    sm: 'gap-1.5 px-3 py-[5px] text-xs',
+    md: 'gap-2 px-3.5 py-1.5 text-sm',
   }
 
   const iconSizeClasses = {
@@ -71,9 +89,17 @@ export function Badge({
     md: 'w-3.5 h-3.5',
   }
 
+  const countEl =
+    count != null ? (
+      <span className="font-mono text-[11px] tabular-nums opacity-80">
+        {count}
+      </span>
+    ) : null
+
   return (
     <span
       className={cn(
+        baseClasses,
         variantClasses[variant],
         sizeClasses[size],
         className
@@ -84,7 +110,9 @@ export function Badge({
           {icon}
         </span>
       )}
+      {countPosition === 'leading' && countEl}
       {children}
+      {countPosition === 'trailing' && countEl}
     </span>
   )
 }

--- a/src/components/StatCard/StatCard.test.tsx
+++ b/src/components/StatCard/StatCard.test.tsx
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { StatCard } from './StatCard'
+
+describe('StatCard', () => {
+  const tile = (label: string) =>
+    // the tile is the nearest element carrying the gp-stat-card class
+    screen.getByText(label).closest('.gp-stat-card') as HTMLElement
+
+  describe('surface', () => {
+    it('defaults to the muted fill', () => {
+      render(<StatCard label="Sent" value={42} />)
+      expect(tile('Sent')).toHaveClass('bg-gray-50')
+    })
+
+    it('renders a transparent tile when surface="plain"', () => {
+      render(<StatCard label="Sent" value={42} surface="plain" />)
+      const el = tile('Sent')
+      expect(el).toHaveClass('bg-transparent')
+      expect(el).not.toHaveClass('bg-gray-50')
+    })
+
+    it('applies plain across tiled variants (centered)', () => {
+      render(<StatCard label="Sent" value={42} variant="centered" surface="plain" />)
+      expect(tile('Sent')).toHaveClass('bg-transparent')
+    })
+
+    it('drops the accent fill when accent color is plain', () => {
+      render(<StatCard label="Sync" value={5} color="accent" surface="plain" />)
+      const el = tile('Sync')
+      expect(el).toHaveClass('bg-transparent')
+      expect(el).not.toHaveClass('bg-white/80')
+    })
+  })
+
+  describe('display variant', () => {
+    it('renders no tile chrome regardless of surface', () => {
+      render(<StatCard label="Founders" value={99} variant="display" surface="plain" />)
+      expect(screen.getByText('Founders').closest('.gp-stat-card')).toBeNull()
+    })
+  })
+})

--- a/src/components/StatCard/StatCard.tsx
+++ b/src/components/StatCard/StatCard.tsx
@@ -54,6 +54,16 @@ export interface StatCardProps {
   color?: 'default' | 'accent'
 
   /**
+   * Tile surface treatment.
+   * - muted: filled tile (default) — the standalone look, reads on a page background
+   * - plain: transparent, inherits the parent surface — use when nesting inside a
+   *   Card / SectionCard so the tile doesn't go muddy grey-on-white
+   *
+   * Ignored by `variant="display"`, which is always chrome-less.
+   */
+  surface?: 'muted' | 'plain'
+
+  /**
    * Additional CSS classes
    */
   className?: string
@@ -90,6 +100,7 @@ export function StatCard({
   trend,
   variant = 'default',
   color = 'default',
+  surface = 'muted',
   className = '',
 }: StatCardProps) {
   const isNumeric = typeof value === 'number' || !isNaN(Number(value))
@@ -99,16 +110,28 @@ export function StatCard({
     default: {
       label: 'text-navy-500 dark:text-navy-300',
       value: 'text-navy-900 dark:text-navy-100',
-      bg: 'bg-gray-50 dark:bg-navy-800/50',
       icon: 'text-navy-400 dark:text-navy-400',
     },
     accent: {
       label: 'text-orange-600 dark:text-orange-400',
       value: 'text-orange-800 dark:text-orange-200',
-      bg: 'bg-white/80 dark:bg-navy-800/80',
       icon: 'text-orange-500 dark:text-orange-400',
     },
   }
+
+  // Surface fill by color × surface. `plain` is transparent so a nested tile
+  // inherits the card behind it instead of stacking grey-on-white.
+  const surfaceClasses = {
+    default: {
+      muted: 'bg-gray-50 dark:bg-navy-800/50',
+      plain: 'bg-transparent',
+    },
+    accent: {
+      muted: 'bg-white/80 dark:bg-navy-800/80',
+      plain: 'bg-transparent',
+    },
+  }
+  const surfaceBg = surfaceClasses[color][surface]
 
   // Display variant: huge cream numeral above tiny uppercase caption, no chrome.
   // Used in Hero blocks and marketing-style number callouts.
@@ -148,7 +171,7 @@ export function StatCard({
   // Inline variant: label on top, value below, left-aligned.
   if (variant === 'inline') {
     return (
-      <div className={cn('gp-stat-card flex flex-col items-start gap-0.5', colorClasses[color].bg, className)}>
+      <div className={cn('gp-stat-card flex flex-col items-start gap-0.5', surfaceBg, className)}>
         {/* Label on top */}
         <span className={cn('text-xs leading-tight', colorClasses[color].label)}>
           {label}
@@ -165,7 +188,7 @@ export function StatCard({
   // Centered variant: label on top, value below, centered.
   if (variant === 'centered') {
     return (
-      <div className={cn('gp-stat-card flex flex-col items-center text-center gap-1', colorClasses[color].bg, className)}>
+      <div className={cn('gp-stat-card flex flex-col items-center text-center gap-1', surfaceBg, className)}>
         {/* Label on top */}
         <span className={cn('text-xs leading-tight', colorClasses[color].label)}>
           {label}
@@ -186,7 +209,7 @@ export function StatCard({
   }
 
   return (
-    <div className={cn('gp-stat-card flex flex-col items-start', colorClasses[color].bg, variantClasses[variant], className)}>
+    <div className={cn('gp-stat-card flex flex-col items-start', surfaceBg, variantClasses[variant], className)}>
       {/* Value and icon row */}
       <div className="flex items-center gap-2 min-w-0">
         {icon && (

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -196,44 +196,42 @@
     @apply inline-block w-1.5 h-1.5 rounded-full bg-orange-500 shrink-0;
   }
 
+  /*
+   * Badge variants own COLOR + semantic weight only; geometry (layout, size,
+   * radius) lives in the Badge component's base + size classes so the two never
+   * fight. Light mode: soft tint + solid hairline border, no glow. Semantic
+   * "flag" variants (success/warning/error) read at font-semibold; the quieter
+   * info/neutral tags stay font-medium.
+   */
   .gp-badge-success {
-    @apply inline-flex items-center gap-1 px-1.5 py-0.5 text-xs font-medium rounded-full;
-    @apply bg-white text-emerald-700 border border-emerald-200/50;
+    @apply font-semibold bg-emerald-50 text-emerald-800 border border-emerald-200;
     @apply dark:bg-navy-800 dark:text-emerald-400 dark:border-emerald-700/50;
-    box-shadow: 0 0 8px rgb(16 185 129 / 0.3); /* emerald-500 */
   }
 
   .gp-badge-warning {
-    @apply inline-flex items-center gap-1 px-1.5 py-0.5 text-xs font-medium rounded-full;
-    @apply bg-white text-amber-600 border border-amber-200/50;
+    @apply font-semibold bg-amber-50 text-amber-800 border border-amber-200;
     @apply dark:bg-navy-800 dark:text-amber-400 dark:border-amber-600/50;
-    box-shadow: 0 0 8px rgb(245 158 11 / 0.3); /* amber-500 */
   }
 
   .gp-badge-error {
-    @apply inline-flex items-center gap-1 px-1.5 py-0.5 text-xs font-medium rounded-full;
-    @apply bg-white text-rose-700 border border-rose-200/50;
+    @apply font-semibold bg-rose-50 text-rose-800 border border-rose-200;
     @apply dark:bg-navy-800 dark:text-rose-400 dark:border-rose-600/50;
-    box-shadow: 0 0 8px rgb(244 63 94 / 0.3); /* rose-500 */
   }
 
   .gp-badge-info {
-    @apply inline-flex items-center gap-1 px-1.5 py-0.5 text-xs font-medium rounded-full;
-    @apply bg-white text-navy-700 border border-navy-200/50;
+    @apply font-medium bg-navy-50 text-navy-700 border border-navy-200;
     @apply dark:bg-navy-800 dark:text-navy-200 dark:border-navy-600/50;
-    box-shadow: 0 0 8px rgb(64 81 117 / 0.3); /* navy-500 */
   }
 
   .gp-badge-neutral {
-    @apply inline-flex items-center gap-1 px-1.5 py-0.5 text-xs font-medium rounded-full;
-    @apply bg-white text-gray-700 border border-gray-200/50;
+    @apply font-medium bg-navy-50 text-navy-500 border border-gray-200;
     @apply dark:bg-navy-800 dark:text-gray-300 dark:border-gray-600/50;
-    box-shadow: 0 0 8px rgb(107 114 128 / 0.3); /* gray-500 */
   }
 
+  /* Tile geometry only — the fill is supplied by StatCard's `surface` prop so
+     the same tile can render muted (standalone) or plain (nested in a card). */
   .gp-stat-card {
-    @apply flex items-center gap-2 bg-gray-50 rounded-md px-3 py-2;
-    @apply dark:bg-navy-800/50;
+    @apply flex items-center gap-2 rounded-md px-3 py-2;
   }
 
   .gp-proportion-chart {


### PR DESCRIPTION
Refreshes **Badge** and **StatCard** to match the Dixie dashboard mock. Two independent deltas, folded into one PR.

## Badge

The mock's badges use a soft tinted fill + solid hairline border + no glow, they're roomier, and several carry a monospace count.

- **Restyled light-mode variants** (`theme.css`): white-fill + halved-opacity border + colored glow → soft `*-50` tint + solid `*-200` border, **no glow**. Text deepens one step (`*-800`) to read against the tint. `neutral` becomes navy-tinted to match the mock; `success`/`info` get the same treatment for family consistency. Dark mode unchanged (the mock is light-only).
- **Variant classes own color only.** `.gp-badge-*` no longer bake in padding/gap/radius — those move to the component's base + `size` classes, so the two can't fight over spacing (the "sizing prop interaction" the mock flagged). Semantic weight stays on the variant: `font-semibold` for flags (success/warning/error), `font-medium` for info/neutral.
- **New `count` / `countPosition` props** (additive, no breaking change): render a `font-mono tabular-nums` count on the `leading` edge (flags — "10 flagged") or `trailing` edge (tags — "other 525").

**Deliberate deviation from the handoff:** the count is **not** `aria-hidden`. It carries meaning ("10 sessions flagged"), so hiding it from screen readers would drop real information. `count={0}` renders correctly (covered by a test).

## StatCard

`gp-stat-card` baked a grey fill that reads muddy grey-on-white when nested inside a white Card/SectionCard (Metrics card, session-detail stat grids).

- **New `surface` prop:** `muted` (default — today's filled tile, zero visual change) or `plain` (transparent, inherits the parent card).
- **Fill control moved fully into the component.** `.gp-stat-card` is now geometry-only; the fill was previously defined *twice* (in the CSS class and via `colorClasses[color].bg`) and relied on utility-layer ordering. Now a single `surfaceClasses[color][surface]` map owns it.
- Applies across all tiled variants (default/compact/inline/centered) and both colors; `variant="display"` is chrome-less and ignores `surface`.

## Tests & playground

- Added `Badge.test.tsx` (variant classes, count render, `count={0}`, leading/trailing order) and `StatCard.test.tsx` (muted default, plain transparent, accent+plain, display-ignores-surface).
- `BadgeDemo` gets a "With Count" section; `StatCardDemo` gets a "Surface: muted vs plain" side-by-side inside white cards so the muddy-vs-clean difference is the visual contract.

## Risk

- Badge delta-1 changes the look of **every** existing `Badge` in consuming apps — worth a visual pass on any screen already using badges.
- StatCard `surface="muted"` is the default, so existing StatCards are unchanged; `plain` is opt-in.

`npm run typecheck`, `npm run build`, and the new tests all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
